### PR TITLE
Allow Youtube Ids starting with "-"

### DIFF
--- a/Classes/Service/ParseIDService.php
+++ b/Classes/Service/ParseIDService.php
@@ -152,8 +152,8 @@ class ParseIDService
             }
             return $array[$returnKey];
         }
-        // The ID has to start with a letter / number / _
-        if (preg_match('/^[A-Za-z0-9_]/', $url)) {
+        // The ID has to start with a letter / number / _ / -
+        if (preg_match('/^[A-Za-z0-9_-]/', $url)) {
             return $url;
         }
         return null;


### PR DESCRIPTION
There are also YouTube Id's starting with a "-". Currently these videos can get embedded if you add a full YouTube url, but not with just the Id.

E.g:
Works: "https://www.youtube.com/watch?v=-0Y4EyqhIc4"
Doesn't work: "-0Y4EyqhIc4"